### PR TITLE
Publish ksComponents as a package for Delphinus package manager

### DIFF
--- a/Delphinus.Info.json
+++ b/Delphinus.Info.json
@@ -1,9 +1,15 @@
 {
-  "id": "{40e45656-8229-43be-aa34-8635b0b154e5}",
-  "name": "ksComponents",
-  "platforms": "Win32;Win64",
-  "package_compiler_min": 29,
-  "package_compiler_max": 32,
-  "compiler_min": 29,
-  "compiler_max": 32
+   "id":"{40e45656-8229-43be-aa34-8635b0b154e5}",
+   "name":"ksComponents",
+   "platforms":"Win32;Win64;OSX32;Android;IOSDevice32;IOSDevice64",
+   "package_compiler_min":29,
+   "package_compiler_max":32,
+   "compiler_min":29,
+   "compiler_max":32,
+   "repository":{
+      "type":"Bitbucket",
+      "user":"gmurt",
+      "name":"kscomponents",
+      "redirect_issues":true
+   }
 }

--- a/Delphinus.Info.json
+++ b/Delphinus.Info.json
@@ -1,0 +1,9 @@
+{
+  "id": "{40e45656-8229-43be-aa34-8635b0b154e5}",
+  "name": "ksComponents",
+  "platforms": "Win32;Win64",
+  "package_compiler_min": 29,
+  "package_compiler_max": 32,
+  "compiler_min": 29,
+  "compiler_max": 32
+}

--- a/Delphinus.Install.json
+++ b/Delphinus.Install.json
@@ -1,11 +1,11 @@
 {
   "search_pathes": [{
     "pathes": ".",
-    "platforms": "Win32;Win64"
+    "platforms": "Win32;Win64;OSX32;Android;IOSDevice32;IOSDevice64"
   }],
   "browsing_pathes": [{
     "pathes": ".",
-    "platforms": "Win32;Win64"
+    "platforms": "Win32;Win64;OSX32;Android;IOSDevice32;IOSDevice64"
   }],
   "source_folders": [{
     "folder": "."

--- a/Delphinus.Install.json
+++ b/Delphinus.Install.json
@@ -1,0 +1,37 @@
+{
+  "search_pathes": [{
+    "pathes": ".",
+    "platforms": "Win32;Win64"
+  }],
+  "browsing_pathes": [{
+    "pathes": ".",
+    "platforms": "Win32;Win64"
+  }],
+  "source_folders": [{
+    "folder": "."
+  },
+  {
+    "folder": "Samples",
+    "recursive": true
+  },
+  {
+    "folder": "Tests",
+    "recursive": true
+  }],
+  "projects": [{
+    "project": "KernowSoftwareFMX.dproj",
+    "compiler": 29
+  },
+  {
+    "project": "KernowSoftwareFMX.dproj",
+    "compiler": 30
+  },
+  {
+    "project": "KernowSoftwareFMX.dproj",
+    "compiler": 31
+  },
+  {
+    "project": "KernowSoftwareFMX.dproj",
+    "compiler": 32
+  }]
+}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
-# THE KSCOMPONENTS PROJECT IS NOW HOSTED ON BITBUCKET 
+This is a read only fork for Delphinus-Support
+----------------------------------------------
 
-https://bitbucket.org/gmurt/kscomponents
+# THE KSCOMPONENTS PROJECT IS NOW HOSTED ON BITBUCKET 
+please report any issues or pull requests on [the main repository](https://bitbucket.org/gmurt/kscomponents)
+
 
 
 # KernowSoftwareFMX
@@ -19,7 +22,7 @@ If you'd like to support the ksComponents project, you can do so at the followin
 
 http://www.kernow-software.co.uk/?page_id=397
 
-###TksTableView
+### TksTableView
 
 - Cached table view provides native performance regardless of the number of text/items/graphics added
 - support for embedded switches
@@ -34,7 +37,7 @@ http://www.kernow-software.co.uk/?page_id=397
 - "Sticky" headers
 
 
-###TksSlideMenu
+### TksSlideMenu
 
 - set menu background colour
 - set selected item colour
@@ -45,34 +48,34 @@ http://www.kernow-software.co.uk/?page_id=397
 - inherites from non-visual Tcomponent for quick integration into existing projects
 - uses bitmap caching for optimised performance
 
-###TksSegmentButtons
+### TksSegmentButtons
 
 - segment button component
 - support for iOS style badges
 
-###TksFormTransition
+### TksFormTransition
 
 - component for animating transitions between forms
 
-###TksTabControl
+### TksTabControl
 
 - Tab control component with support for different colours/themes
 - Large number of built-in icons
 - Support for iOS style badges
 
-###TksNetHttpClient
+### TksNetHttpClient
 
 - enhanced http client with ASync Get method
 
-###TksTileMenu
+### TksTileMenu
 
 - simple but effective main menu component
 
-###TksChatView
+### TksChatView
 
 - component for building iOS style chat applications
 
-###TksSpeedButton
+### TksSpeedButton
 
 - TSpeedButton descendant with support for iOS style badges
 


### PR DESCRIPTION
💡 **Idea to consider**

Maybe the whole **Delphinus** project (https://github.com/Memnarch/Delphinus) is not so mature but I think it's just really nice tool for Delphi because it can work directly with GitHub (in opposite to GetIt).

**I know that You have moved main repository to Bitbucket but now it is possible to lik this kind of repos too** 😁 
Check https://github.com/Spring4D/Spring4D how easy it is 😎 

**Why?**
 - to spread a word about ksComponents
 - to be able to add ksComponents as dependency for other packages.
 - to make download and updates quick & easy

The line with keyword `Delphinus-Support` in readme is needed to find ksComponents repository via GitHub API.

In case of any questions / doubts check https://github.com/Memnarch/Delphinus/wiki/External-Timelines or ask directly @Memnarch (author of this tool)

PS. Are typos in **TksCamara** (Cam**e**ra => Cam**a**ra) intended?